### PR TITLE
Add helper functions for wildcard match

### DIFF
--- a/helper/strutil/strutil.go
+++ b/helper/strutil/strutil.go
@@ -32,6 +32,18 @@ func StrListContains(haystack []string, needle string) bool {
 	return false
 }
 
+// StrListContainsWildcard looks for a regex in a list of strings.
+func StrListContainsWildcard(haystack []string, needle string) bool {
+	var result bool
+	for _, item := range haystack {
+		if GlobbedStringsMatch(item, needle) {
+			result = true
+			break
+		}
+	}
+	return result
+}
+
 // StrListSubset checks if a given list is a subset
 // of another set
 func StrListSubset(super, sub []string) bool {

--- a/helper/strutil/strutil_test.go
+++ b/helper/strutil/strutil_test.go
@@ -423,3 +423,47 @@ func TestStrUtil_RemoveDuplicates(t *testing.T) {
 		}
 	}
 }
+
+func TestStrutil_ListContainsWildcard(t *testing.T) {
+	haystack := []string{
+		"dev",
+		"ops*",
+		"*ops",
+		"root/*",
+		"*/root",
+		"*-dev",
+		"dev-*",
+		"_*_",
+	}
+	if StrListContainsWildcard(haystack, "not-existing-value") {
+		t.Fatalf("Value shouldn't exist")
+	}
+	if StrListContainsGlob(haystack, "_test_") {
+		t.Fatalf("Value shouldn't exist")
+	}
+
+	if !StrListContainsWildcard(haystack, "root/test") {
+		t.Fatalf("Value should exist")
+	}
+	if !StrListContainsWildcard(haystack, "test/root") {
+		t.Fatalf("Value should exist")
+	}
+	if !StrListContainsWildcard(haystack, "ops_test") {
+		t.Fatalf("Value should exist")
+	}
+	if !StrListContainsWildcard(haystack, "test_ops") {
+		t.Fatalf("Value should exist")
+	}
+	if !StrListContainsWildcard(haystack, "ops") {
+		t.Fatalf("Value should exist")
+	}
+	if !StrListContainsWildcard(haystack, "dev") {
+		t.Fatalf("Value should exist")
+	}
+	if !StrListContainsWildcard(haystack, "test-dev") {
+		t.Fatalf("Value should exist")
+	}
+	if !StrListContainsWildcard(haystack, "dev-test") {
+		t.Fatalf("Value should exist")
+	}
+}


### PR DESCRIPTION
This is PR # 1 of a set of 2 PRs to add support for wildcard string matching for Service Accounts in the Kubernetes Auth Plugin.
